### PR TITLE
注释oracle.py文件中filter_sql函数内容，以修复该部分引入的错误ORA-00918

### DIFF
--- a/sql/engines/oracle.py
+++ b/sql/engines/oracle.py
@@ -644,14 +644,15 @@ class OracleEngine(EngineBase):
         return result
 
     def filter_sql(self, sql="", limit_num=0):
-        sql_lower = sql.lower()
-        # 对查询sql增加limit限制
-        if re.match(r"^select|^with", sql_lower) and not (
-            re.match(r"^select\s+sql_audit.", sql_lower)
-            and sql_lower.find(" sql_audit where rownum <= ") != -1
-        ):
-            sql = f"select sql_audit.* from ({sql.rstrip(';')}) sql_audit where rownum <= {limit_num}"
-        return sql.strip()
+        #sql_lower = sql.lower()
+        ## 对查询sql增加limit限制
+        #if re.match(r"^select|^with", sql_lower) and not (
+        #    re.match(r"^select\s+sql_audit.", sql_lower)
+        #    and sql_lower.find(" sql_audit where rownum <= ") != -1
+        #):
+        #    sql = f"select sql_audit.* from ({sql.rstrip(';')}) sql_audit where rownum <= {limit_num}"
+        #return sql.strip()
+        return sql
 
     def query(
         self,


### PR DESCRIPTION
1、oracle.py的646行filter_sql函数作用是限制查询返回的行数。如果查询SQL的查询字段列表包含同名列，经过filter_sql函数处理之后的SQL，因为查询字段列表sql_audit.*中存在相同名称的列，在数据库中执行会报错ORA-00918。原查询SQL的查询字段列表虽然存在同名列，但有不同的表别名来区分，因此在数据库中执行不会报错。例如sql：select a.*,b.* from a,b where a.custid=b.custid; 该SQL可以在数据库中正常执行，但在archery平台上执行会报错ORA-00918。
2、oracle.py中689行cursor.fetchmany(int(limit_num))已经有限制查询返回行数的作用，所以不必通过filter_sql函数来再次限制查询返回行数。